### PR TITLE
Add 'self.ref' to __repr__()

### DIFF
--- a/geoindex/geo_point.py
+++ b/geoindex/geo_point.py
@@ -41,6 +41,8 @@ class GeoPoint(object):
         """
         Machine representation of Point instance.
         """
+        if self.ref is not None:
+            return 'Point({0}, {1}) - {2}'.format(self.latitude, self.longitude, self.ref)
         return 'Point({0}, {1})'.format(self.latitude, self.longitude)
 
     __str__ = __repr__


### PR DESCRIPTION
I think it would be useful to add the 'ref' slot to the `__repr__` method, don't you think?

Related to this question:
http://stackoverflow.com/questions/36497902/referencing-with-geoindex
