### PR TITLE
get_nearest_points returns point,distance instead of distance,point

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ and use it after::
         index.add_point(GeoPoint(lat, lng, ref=airport))
 
     center_point = GeoPoint(37.7772448, -122.3955118)
-    for distance, point in index.get_nearest_points(center_point, 10, 'km'):
+    for point, distance  in index.get_nearest_points(center_point, 10, 'km'):
         print("We airport {0} in {1} km".format(point.ref, distance))
 
 


### PR DESCRIPTION
With reference to :
This function returns point,distance

def get_nearest_points(self, center_point, radius, unit='km'):
        """
        return list of geo points from circle with given center and radius
        :param center_point: GeoPoint with center of search circle
        :param radius: radius of search circle
        :return: generator with tuple with GeoPoints and distance
        """
        assert isinstance(center_point, GeoPoint), \
            'point should be GeoPoint instance'
        for point in self.get_nearest_points_dirty(center_point, radius):
            distance = point.distance_to(center_point, unit)
            if distance <= radius:
                yield point, distance